### PR TITLE
fix(deno_cli): fix permission args

### DIFF
--- a/src/deno_cli.rs
+++ b/src/deno_cli.rs
@@ -10,8 +10,8 @@ pub fn run(repo_name: &str, artifact: &Artifact, args: &[&str], verbose: bool) -
             command.arg("--unstable");
         }
     }
-    if let Some(permissions) = &artifact.permissions {
-        command.args(permissions);
+    if artifact.permissions.is_some() {
+        command.args(artifact.get_deno_permissions());
     }
     if artifact.import_map.is_some() {
         command.arg("--import-map");


### PR DESCRIPTION
I wrote the `dbang-catalog.json` file according to this [example](https://dbang.dev/docs/tutorial-basics/explore-dbang-catalog),
like this:
```json
{
  "script-name": {
    "permissions": ["allow-net"],
    ...
  }
}
```
when I ran the `dbang` command, there was an error message:
```
error: Module not found "file:///path-to-current-dir/allow-net".
```
it caused by permission args didn't use `--`, like run this command:
```
deno run allow-net main.ts
```
this PR fix the bug.

Finally, I hope to add a `rustfmt.toml` file for this project and format before commit, because editor could auto format with different formatter, and it could cause diff.